### PR TITLE
Added support for $uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ mgeneratejs '{"ip_addresses": {"$array": {"of": "$ip", "number": {"$integer": {"
 - [`$numberDecimal`](#numberdecimal): Returns a MongoDB Decimal128 number.
 - [`$numberLong`](#numberlong): Returns a MongoDB Long (Int64) number.
 - [`$objectid`](#objectid): Returns MongoDB ObjectID.
+- [`$uuid`](#uuid): Returns BSON UUID.
 - [`$regex`](#regex): Returns a Regular Expression object.
 - [`$timestamp`](#timestamp): Returns a MongoDB Timestamp.
 
@@ -452,6 +453,19 @@ _Aliases_
 > ```
 >
 > Returns `{"_id":{"$oid":"574ac75f725f4447309ab587"}}`.
+
+
+### `$uuid`
+
+Returns a new MongoDB Binary UUID.
+
+> **Example**
+>
+> ```
+> {"entry_id": "$uuid"}
+> ```
+>
+> Returns `{"entry_id": UUID("dee11d4e-63c6-4d90-983c-5c9f1e79e96c")}`.
 
 
 ### `$pick`

--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -24,6 +24,7 @@ module.exports = {
    * MongoDB native types
    */
   objectid: require('./objectid'),
+  uuid: require('./uuid'),
   binary: require('./binary'),
   long: require('./long'),
   decimal: require('./decimal'),

--- a/lib/operators/uuid.js
+++ b/lib/operators/uuid.js
@@ -1,0 +1,14 @@
+/* eslint new-cap: 0 */
+var mongodb = require('mongodb');
+var uuidv4 = require('uuid/v4');
+
+// var debug = require('debug')('mgenerate:objectid');
+
+/**
+ * $uuid returns a BSON UUID.
+ *
+ * @return {core.BSON.Binary}              A random UUIDv4 object
+ */
+module.exports = function() {
+  return mongodb.Binary(uuidv4(), mongodb.Binary.SUBTYPE_UUID);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mgeneratejs",
   "description": "Generate rich random data based on a JSON template file.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "scripts": {
     "fmt": "mongodb-js-fmt",
     "check": "mongodb-js-precommit",
@@ -22,8 +22,10 @@
     "event-stream": "^3.3.2",
     "faker": "^3.1.0",
     "lodash": "^4.17.4",
+    "mongodb": "^3.0.3",
     "mongodb-extended-json": "^1.6.3",
-    "yargs": "^6.3.0"
+    "yargs": "^6.3.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "eslint-config-mongodb-js": "^2.2.0",


### PR DESCRIPTION
This seems to work but creates ugly entries like `[{"$binary":"YTNhZTU0Y2ItZTczMS00YmEwLTk1ZmYtNDM5N2YxZmI5OWVk","$type":"4"}`. Any idea how I can customize the JSON output? 