### PR TITLE
New operator $pickset (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,14 +476,14 @@ _Options_
 
 ### `$pickset`
 
-Takes an array and a number `element` and returns a new n-element array
+Takes an array and a number `quantity` and returns a new n-element array
 containing unique values from the input array. If the number is larger than the
 length of the array, return `$missing` instead, which will remove the key from
 the resulting document.
 
 _Options_
 - `array` (required) Array of values or operators to choose from.
-- `element` (optional) The size of the output array. Default `1`.
+- `quantity` (optional) The size of the output array. Default `1`.
 
 
 ### `$point`

--- a/README.md
+++ b/README.md
@@ -474,6 +474,18 @@ _Options_
 > Returns `{"color": "red"}`.
 
 
+### `$pickset`
+
+Takes an array and a number `element` and returns a new n-element array
+containing unique values from the input array. If the number is larger than the
+length of the array, return `$missing` instead, which will remove the key from
+the resulting document.
+
+_Options_
+- `array` (required) Array of values or operators to choose from.
+- `element` (optional) The size of the output array. Default `1`.
+
+
 ### `$point`
 
 Like `$coordinates`, but returns a GeoJSON formatted

--- a/lib/operators/index.js
+++ b/lib/operators/index.js
@@ -5,6 +5,7 @@ module.exports = {
   array: require('./array'),
   choose: require('./choose'),
   pick: require('./pick'),
+  pickset: require('./pickset'),
   join: require('./join'),
   regex: require('./regex'),
   inc: require('./inc'),

--- a/lib/operators/pickset.js
+++ b/lib/operators/pickset.js
@@ -1,0 +1,35 @@
+var _ = require('lodash');
+var chance = require('chance')();
+// var debug = require('debug')('mgenerate:array');
+
+/**
+ * $pickset operator takes an array and an `element` number and returns an
+ * array of length n containing unique values of the input array. If the number is
+ * larger than the length of the array, return `$missing` instead, which will
+ * remove the key from the resulting document.
+ *
+ * @example Returns a set of ["blue", "red"]
+ *
+ * {"color": {"$pickset": {"array": ["green", "red", "blue"], "element": 2}}}
+ *
+ * @param  {Function} evaluator   evaluator function, passed in for every operator
+ * @param  {Object} options       options to configure the array operator
+ * @return {Array}                array of `number` elements
+ */
+module.exports = function(evaluator, options) {
+  var replacement;
+
+  // default returns one element
+  options = evaluator(_.defaults(options, {
+    element: 1
+  }));
+
+  if (_.isArray(options.array) && _.isInteger(options.element) &&
+  options.element >= 0 && options.element <= options.array.length) {
+    replacement = chance.pickset(options.array, options.element);
+  } else {
+    replacement = '$missing';
+  }
+
+  return evaluator(replacement, true);
+};

--- a/lib/operators/pickset.js
+++ b/lib/operators/pickset.js
@@ -3,30 +3,30 @@ var chance = require('chance')();
 // var debug = require('debug')('mgenerate:array');
 
 /**
- * $pickset operator takes an array and an `element` number and returns an
+ * $pickset operator takes an array and an `quantity` number and returns an
  * array of length n containing unique values of the input array. If the number is
  * larger than the length of the array, return `$missing` instead, which will
  * remove the key from the resulting document.
  *
  * @example Returns a set of ["blue", "red"]
  *
- * {"color": {"$pickset": {"array": ["green", "red", "blue"], "element": 2}}}
+ * {"color": {"$pickset": {"array": ["green", "red", "blue"], "quantity": 2}}}
  *
  * @param  {Function} evaluator   evaluator function, passed in for every operator
  * @param  {Object} options       options to configure the array operator
- * @return {Array}                array of `number` elements
+ * @return {Array}                array of `quantity` elements
  */
 module.exports = function(evaluator, options) {
   var replacement;
 
   // default returns one element
   options = evaluator(_.defaults(options, {
-    element: 1
+    quantity: 1
   }));
 
-  if (_.isArray(options.array) && _.isInteger(options.element) &&
-  options.element >= 0 && options.element <= options.array.length) {
-    replacement = chance.pickset(options.array, options.element);
+  if (_.isArray(options.array) && _.isInteger(options.quantity) &&
+  options.quantity >= 0 && options.quantity <= options.array.length) {
+    replacement = chance.pickset(options.array, options.quantity);
   } else {
     replacement = '$missing';
   }

--- a/test/operators.test.js
+++ b/test/operators.test.js
@@ -98,26 +98,26 @@ context('Operators', function() {
 
   describe('$pickset', function() {
     it('should pick the correct number of element', function() {
-      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 2}}});
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], quantity: 2}}});
       assert.equal(res.color.length, 2);
     });
     it('should not pick the same item twice', function() {
-      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 3}}});
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], quantity: 3}}});
       var expset = ['green', 'red', 'blue'].sort();
       assert.deepEqual(res.color.sort(), expset);
     });
-    it('should pick one element if `element` is not specified', function() {
+    it('should pick one element if `quantity` is not specified', function() {
       var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue']}}});
       assert.equal(res.color.length, 1);
     });
-    it('should return $missing if element is out of array bounds', function() {
-      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 4}}});
+    it('should return $missing if quantity is out of array bounds', function() {
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], quantity: 4}}});
       assert.ok(!_.has(res, 'color'));
-      res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: -1}}});
+      res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], quantity: -1}}});
       assert.ok(!_.has(res, 'color'));
     });
     it('should return $missing if `array` is not an array', function() {
-      var res = mgenerate({color: {$pickset: {array: 'red', element: 3}}});
+      var res = mgenerate({color: {$pickset: {array: 'red', quantity: 3}}});
       assert.ok(!_.has(res, 'color'));
     });
   });

--- a/test/operators.test.js
+++ b/test/operators.test.js
@@ -96,6 +96,32 @@ context('Operators', function() {
     });
   });
 
+  describe('$pickset', function() {
+    it('should pick the correct number of element', function() {
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 2}}});
+      assert.equal(res.color.length, 2);
+    });
+    it('should not pick the same item twice', function() {
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 3}}});
+      var expset = ['green', 'red', 'blue'].sort();
+      assert.deepEqual(res.color.sort(), expset);
+    });
+    it('should pick one element if `element` is not specified', function() {
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue']}}});
+      assert.equal(res.color.length, 1);
+    });
+    it('should return $missing if element is out of array bounds', function() {
+      var res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: 4}}});
+      assert.ok(!_.has(res, 'color'));
+      res = mgenerate({color: {$pickset: {array: ['green', 'red', 'blue'], element: -1}}});
+      assert.ok(!_.has(res, 'color'));
+    });
+    it('should return $missing if `array` is not an array', function() {
+      var res = mgenerate({color: {$pickset: {array: 'red', element: 3}}});
+      assert.ok(!_.has(res, 'color'));
+    });
+  });
+
 
   describe('$array', function() {
     it('should create a fixed-length array', function() {


### PR DESCRIPTION
`mgeneratejs` currently cannot call chance's `pickset()` function, due to the function not accepting JSON object as its parameter.

Using the templating function also does not provide a satisfactory solution, since it returns a string instead of an array:

```
$ mgeneratejs '{"numbers": "{{chance.pickset([1,2,3],2)}}"}'
{"numbers":"2,3"}
```

This PR addresses this by acting as a wrapper for chance's `pickset()` function, by following the format of the `$pick` operator:

```
$ mgeneratejs '{"numbers": {"$pickset": {"array": [1,2,3], "element": 2}}}'
{"numbers":[3,1]}
```