### PR TITLE
Ensure $numberDecimal returns the correct number of digits

### DIFF
--- a/lib/operators/decimal.js
+++ b/lib/operators/decimal.js
@@ -20,7 +20,21 @@ module.exports = function(evaluator, options) {
     max: 1000,
     fixed: 2
   }));
-  return bson.Decimal128.fromString(String(chance.floating({
-    min: options.min, max: options.max, fixed: options.fixed
-  })));
+
+  var getnum = function() {
+    return String(chance.floating({
+      min: options.min, max: options.max, fixed: options.fixed
+    }))
+  }
+
+  var num = getnum();
+
+  // Ensure that fixed decimal value contains no trailing zeroes
+  if(options.fixed > 0 && options.min < options.max) {
+    while(num.match(/\.\d+$/)[0].length < options.fixed + 1) {
+      num = getnum();
+    }
+  }
+
+  return bson.Decimal128.fromString(num);
 };

--- a/lib/operators/decimal.js
+++ b/lib/operators/decimal.js
@@ -24,14 +24,14 @@ module.exports = function(evaluator, options) {
   var getnum = function() {
     return String(chance.floating({
       min: options.min, max: options.max, fixed: options.fixed
-    }))
-  }
+    }));
+  };
 
   var num = getnum();
 
   // Ensure that fixed decimal value contains no trailing zeroes
-  if(options.fixed > 0 && options.min < options.max) {
-    while(num.match(/\.\d+$/)[0].length < options.fixed + 1) {
+  if (options.fixed > 0 && options.min < options.max) {
+    while (num.match(/\.\d+$/)[0].length < options.fixed + 1) {
       num = getnum();
     }
   }


### PR DESCRIPTION
`$numberDecimal` passes through its parameter to [chance's `floating()` function](http://chancejs.com/basics/floating.html). However, the parameter `{ fixed: n }` returns _at most n digits_. Thus it is possible that it can return a number with trailing zeroes.

This causes the [$numberDecimal test with fixed parameter](https://github.com/rueckstiess/mgeneratejs/blob/master/test/operators.test.js#L354-L358) to fail occasionally, since the test specified it should return 5 digits, but sometimes it could return only 4 or even 3 digits due to trailing zeroes.

This PR ensures that the `fixed` parameter is always respected.